### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.0
+
+- **Breaking:** Remove an unneeded lifetime from the public API. (#6)
+
 # Version 0.2.0
 
 - **Breaking:** Add support for WASM targets by disabling `wait()` on them. (#3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "event-listener-strategy"
 # Make sure to update CHANGELOG.md when the version is bumped here.
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.59"


### PR DESCRIPTION
- **Breaking:** Remove an unneeded lifetime from the public API. (#6)