### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.0
+
+- **Breaking:** Bump `event-listener` to v4.0.0. (#10)
+
 # Version 0.3.0
 
 - **Breaking:** Remove an unneeded lifetime from the public API. (#6)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "event-listener-strategy"
 # Make sure to update CHANGELOG.md when the version is bumped here.
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.59"


### PR DESCRIPTION
- **Breaking:** Bump `event-listener` to v4.0.0. (#10)
