### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.5.0
+
+- **Breaking:** Bump `event-listener` to v5.0.0. (#12)
+- Bump MSRV to 1.60. (#14)
+- Make `NonBlocking` `Send` and `Sync`. (#15)
+
 # Version 0.4.0
 
 - **Breaking:** Bump `event-listener` to v4.0.0. (#10)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "event-listener-strategy"
 # Make sure to update CHANGELOG.md when the version is bumped here.
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.60"


### PR DESCRIPTION
- **Breaking:** Bump `event-listener` to v5.0.0. (#12)
- Bump MSRV to 1.60. (#14)
- Make `NonBlocking` `Send` and `Sync`. (#15)
