### PR TITLE
v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.1
+
+- Fix the `repository` field in `Cargo.toml` to point to the correct repository. (#17)
+
 # Version 0.5.0
 
 - **Breaking:** Bump `event-listener` to v5.0.0. (#12)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "event-listener-strategy"
 # Make sure to update CHANGELOG.md when the version is bumped here.
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.60"


### PR DESCRIPTION
- Fix the `repository` field in `Cargo.toml` to point to the correct repository. (#17)
