### PR TITLE
Expose `portable-atomic` Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ pin-project-lite = "0.2.12"
 default = ["std"]
 loom = ["event-listener/loom"]
 std = ["event-listener/std"]
+portable-atomic = ["event-listener/portable-atomic"]
 
 [dev-dependencies]
 futures-lite = "2.0.0"


### PR DESCRIPTION
# Objective

`event-listener-strategy` is compatible with platforms that require the use of `portable-atomic`, but you must take a direct dependency on `event-listener` in order to enable the `event-listener/portable-atomic` feature. This is mildly annoying, and was noticed in [`async-channel/#106`](https://github.com/smol-rs/async-channel/pull/106).

## Solution

Expose a `portable-atomic` feature in `event-listener-strategy` itself, allowing crates to enable `event-listener/portable-atomic` through their existing dependency on `event-listener-strategy`.