### PR TITLE
Release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.4
+
+- Add `portable-atomic` feature that exposes `event-listener`'s underlying `portable-atomic` feature. (#27)
+
 # Version 0.5.3
 
 - Add `loom` feature that exposes `event-listener`'s underlying `loom` feature. (#24)
@@ -31,4 +35,3 @@
 # Version 0.1.0
 
 - Initial version
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "event-listener-strategy"
 # Make sure to update CHANGELOG.md when the version is bumped here.
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 authors = ["John Nunley <dev@notgull.net>"]
 rust-version = "1.60"


### PR DESCRIPTION
Changes:
- Add `portable-atomic` feature that exposes `event-listener`'s underlying `portable-atomic` feature. (#27)